### PR TITLE
add HDF5 and FITSIO explicitly to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,7 @@ julia 0.4
 NFFT
 Wavelets
 OIFITS
+HDF5
 JLD
 OptimPack
+FITSIO


### PR DESCRIPTION
Instead of assuming they will be present as indirect dependencies

Also note that your test of `Pkg.installed("PyPlot")` will not interact well with precompilation. You may want to look into how to tie your package into Plots.jl / PlotRecipes etc so you can avoid the precompilation issue and also use multiple backends.
